### PR TITLE
fix name for Romanian language

### DIFF
--- a/langs/hu.json
+++ b/langs/hu.json
@@ -135,7 +135,7 @@
     "qu": "kecsua",
     "rm": "romans",
     "rn": "rundi",
-    "ro": "moldáv",
+    "ro": "román",
     "ru": "orosz",
     "rw": "kinyarvanda",
     "sa": "szanszkrit",


### PR DESCRIPTION
The correct name for the Romanian language in Hungarian is _román_ and not _moldáv_.
In Moldavia the official language is also Romanian (_román_) but sometimes it is called Moldavian(_moldáv_), but Moldavian(_moldáv_) is only a dialect, not an official language.

You can also check the list on [Wikipedia](https://hu.wikipedia.org/wiki/ISO_639-1_nyelvk%C3%B3dok_list%C3%A1ja ) where the name for **ro** is also appears as _román_.
Also I'm a native Hungarian speaker.